### PR TITLE
Update the Plex watchlist base URL

### DIFF
--- a/clean-v140-source/server/api/plextv.ts
+++ b/clean-v140-source/server/api/plextv.ts
@@ -291,7 +291,7 @@ class PlexTvAPI extends ExternalAPI {
           headers: {
             'If-None-Match': cachedWatchlist?.etag,
           },
-          baseURL: 'https://metadata.provider.plex.tv',
+          baseURL: 'https://discover.provider.plex.tv',
           validateStatus: (status) => status < 400, // Allow HTTP 304 to return without error
         }
       );
@@ -315,7 +315,7 @@ class PlexTvAPI extends ExternalAPI {
             const detailedResponse = await this.getRolling<MetadataResponse>(
               `/library/metadata/${watchlistItem.ratingKey}`,
               {
-                baseURL: 'https://metadata.provider.plex.tv',
+                baseURL: 'https://discover.provider.plex.tv',
               }
             );
 

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -291,7 +291,7 @@ class PlexTvAPI extends ExternalAPI {
           headers: {
             'If-None-Match': cachedWatchlist?.etag,
           },
-          baseURL: 'https://metadata.provider.plex.tv',
+          baseURL: 'https://discover.provider.plex.tv',
           validateStatus: (status) => status < 400, // Allow HTTP 304 to return without error
         }
       );
@@ -315,7 +315,7 @@ class PlexTvAPI extends ExternalAPI {
             const detailedResponse = await this.getRolling<MetadataResponse>(
               `/library/metadata/${watchlistItem.ratingKey}`,
               {
-                baseURL: 'https://metadata.provider.plex.tv',
+                baseURL: 'https://discover.provider.plex.tv',
               }
             );
 


### PR DESCRIPTION
#### Description
Updates the Plex watchlist base URL to the new endpoint (https://discover.provider.plex.tv/), replacing the deprecated one (https://metadata.provider.plex.tv/).

#### Issues Fixed or Closed

- Fixes #4228
https://github.com/sct/overseerr/issues/4228